### PR TITLE
Update api.php

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -81,6 +81,7 @@ class FastlyAPI {
     curl_setopt($ch, CURLOPT_URL, $url );
     if ($do_post) {
       curl_setopt($ch, CURLOPT_POST, 1);
+      curl_setopt($ch, CURLOPT_POSTFIELDS, '');
     } else {
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PURGE");      
     }


### PR DESCRIPTION
Depending on php environment, fastly will return error because data is being sent on posts. "The requested resource xxx does not allow request data with POST requests"
