### PR TITLE
Properly register scripts

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -15,11 +15,8 @@ class FastlyAdmin {
     add_action('admin_menu', array(&$this, 'adminPanel'));
     add_action('admin_init', array(&$this, 'adminInit'));
     
-    // Add scripts and styles
-    wp_register_style('fastly.css', $this->resource('fastly.css'));
-    wp_enqueue_style('fastly.css');
-    wp_register_script('fastly.js', $this->resource('fastly.js'));
-    wp_enqueue_script('fastly.js');
+    // Register scripts and styles
+    add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
     
     // Ajax Actions
     add_action('wp_ajax_set_page', array(&$this, 'ajaxSetPage'));
@@ -45,7 +42,20 @@ class FastlyAdmin {
       get_option('fastly_api_port')
     );
   }
-  
+
+  /**
+   * Register scripts and styles needed for the admin option page.
+   *
+   * @return void
+   */
+  function admin_enqueue_scripts() {
+    // Add scripts and styles
+    wp_register_style('fastly.css', $this->resource('fastly.css'));
+    wp_enqueue_style('fastly.css');
+    wp_register_script('fastly.js', $this->resource('fastly.js'));
+    wp_enqueue_script('fastly.js');
+  }
+
   /**
    * @param $p Page name to test.
    * @return True if the given page is valid, false otherwise.

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -48,7 +48,11 @@ class FastlyAdmin {
    *
    * @return void
    */
-  function admin_enqueue_scripts() {
+  function admin_enqueue_scripts( $hook_suffix ) {
+    if ('settings_page_fastly-admin-panel' !== $hook_suffix) {
+      return;
+    }
+
     // Add scripts and styles
     wp_register_style('fastly.css', $this->resource('fastly.css'));
     wp_enqueue_style('fastly.css');


### PR DESCRIPTION
WordPress requires that scripts and styles are enqueued on one of the "enqueue" actions. Not doing so prompts a PHP notice:

```
PHP Notice:  wp_register_script was called <strong>incorrectly</strong>. Scripts and styles should not be registered or enqueued until the <code>wp_enqueue_scripts</code>, <code>admin_enqueue_scripts</code>, or <code>login_enqueue_scripts</code> hooks. Please see <a href="http://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.3.)
```

This PR moves enqueuing to the correct action to avoid this notice, as well as prevent possible plugin conflicts.

Once the scripts were moved, I also addressed enqueuing the script *only when necessary*. They should only be available on the Fastly settings screen.