### PR TITLE
Use the WP HTTP API methods.

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -78,19 +78,14 @@ class FastlyAPI {
       error_log("Purging using POST for " . $url);
     }
 
-    curl_setopt($ch, CURLOPT_URL, $url );
-    if ($do_post) {
-      curl_setopt($ch, CURLOPT_POST, 1);
-      curl_setopt($ch, CURLOPT_POSTFIELDS, '');
-    } else {
-      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PURGE");      
-    }
-    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    $response = curl_exec($ch);
-    curl_close($ch);
-    return !!$response;
-    
+    $args = array(
+        'headers' => $headers,
+        'method'  => (true === $do_post) ? 'POST' : 'PURGE',
+    );
+
+    $response = wp_remote_request($url, $args);
+
+    return ( is_wp_error( $response ) ) ? -1 : $response;
   }
 } 
 


### PR DESCRIPTION
For better backwards and forwards compatibility, use WordPress' HTTP
API. This API will use the best available transport mechanism in the
particular environment. Additionally, if the API is used, maintenance of
the transport is offloaded to WordPress in the event that something
about the transports change.

This change is 1:1 with the previous version using the cURL methods in
PHP. While it may seem that some things were removed (e.g.,
"CURLOPT_RETURNTRANSFER" and "CURLOPT_POSTFIELDS"), these are set by
default in the HTTP API.