### PR TITLE
Address potential XSS/CSRF security issues in plugin

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -60,7 +60,7 @@ class FastlyAdmin {
     wp_register_script('fastly.js', $this->resource('fastly.js'));
     // Expose a WP CSRF nonce to the fastly.js script
     $nonce = wp_create_nonce('fastly-admin');
-    wp_localize_script('fastly.js', 'nonce', $nonce);
+    wp_localize_script('fastly.js', 'fastlyNonce', $nonce);
     wp_enqueue_script('fastly.js');
   }
   
@@ -81,7 +81,7 @@ class FastlyAdmin {
     }
 
     if (isset($_REQUEST['page']) && $this->validPage($_REQUEST['page'])) {
-      update_option('fastly_page', $_REQUEST['page']);
+      update_option('fastly_page', esc_sql($_REQUEST['page']));
       die(1);
     }
     die();
@@ -109,14 +109,14 @@ class FastlyAdmin {
     
     switch ($code) {
       case 200:
-        update_option('fastly_api_key', $body['api_key']);
-        update_option('fastly_service_id', $body['service_id']);
+        update_option('fastly_api_key', esc_sql($body['api_key']));
+        update_option('fastly_service_id', esc_sql($body['service_id']));
         update_option('fastly_page', 'configure');
         
         // Update internal host name
         $parts = explode('/', $_REQUEST['website_address']);
         if (count($parts) >= 3) {
-          update_option('fastly_hostname', $parts[2]);
+          update_option('fastly_hostname', esc_sql($parts[2]));
         }
         
         $response = array('status' => 'success');
@@ -234,7 +234,7 @@ class FastlyAdmin {
         
         <fieldset>
           <p><b>Blog Name</b></p>
-          <p><input class="text" id="customer" type="text" value="' . $customer . '"></p>
+          <p><input class="text" id="customer" type="text" value="' . esc_attr($customer) . '"></p>
           <p><b>Your Name</b></p>
           <p><input class="text" id="name" type="text"></p>
           <p><b>Email Address</b></p>
@@ -245,9 +245,9 @@ class FastlyAdmin {
         
         <fieldset>
           <p><b>Blog Address</b></p>
-          <p><input class="text" id="website_address" type="text" value="' . $website_address . '"></p>
+          <p><input class="text" id="website_address" type="text" value="' . esc_url($website_address) . '"></p>
           <p><b>Server Address</b></p>
-          <p><input class="text" id="address" type="text" value="' . $address . '"></p>
+          <p><input class="text" id="address" type="text" value="' . esc_attr($address) . '"></p>
         </fieldset>
         
         <p><label id="agree_tos_label" for="agree_tos"><input id="agree_tos" type="checkbox"> I agree to the

--- a/lib/api.php
+++ b/lib/api.php
@@ -75,7 +75,7 @@ class FastlyAPI {
     $url = get_option('fastly_api_hostname') . "/purge/" . preg_replace("/^http(s?):\/\//",'', $url);
 
 	if( (bool)get_option('fastly_log_purges') ) {
-      error_log("Purging using POST for " . $url);
+      error_log("Purging using POST for " . esc_url($url));
     }
 
     curl_setopt($ch, CURLOPT_URL, $url );

--- a/static/fastly.js
+++ b/static/fastly.js
@@ -48,8 +48,8 @@ window.Fastly = (function($) {
         data: {
           action: 'set_page',
           page: 'configure',
-          //nonce provided by wp_localize_script() in admin.php
-          nonce: nonce
+          //fastlyNonce provided by wp_localize_script() in admin.php
+          nonce: fastlyNonce
         }
       });
     },
@@ -120,8 +120,8 @@ window.Fastly = (function($) {
           email: email.val(),
           address: address.val(),
           website_address: website_address.val(),
-          //nonce provided by wp_localize_script() in admin.php
-          nonce: nonce
+          //fastlyNonce provided by wp_localize_script() in admin.php
+          nonce: fastlyNonce
         },
         dataType: 'json',
         success: function(response) {

--- a/static/fastly.js
+++ b/static/fastly.js
@@ -45,7 +45,12 @@ window.Fastly = (function($) {
       loadPage('configure');
       $.ajax({
         url: ajaxurl, 
-        data: {action: 'set_page', page: 'configure'}
+        data: {
+          action: 'set_page',
+          page: 'configure',
+          //nonce provided by wp_localize_script() in admin.php
+          nonce: nonce
+        }
       });
     },
     
@@ -114,7 +119,9 @@ window.Fastly = (function($) {
           name: name.val(),
           email: email.val(),
           address: address.val(),
-          website_address: website_address.val()
+          website_address: website_address.val(),
+          //nonce provided by wp_localize_script() in admin.php
+          nonce: nonce
         },
         dataType: 'json',
         success: function(response) {


### PR DESCRIPTION
This PR pulls in commits addressing the lack of escaping for settings fields used in the wordpress plugin. While these fields can only be set by authenticated users/adversaries with DB access the content should be escaped before display regardless. Database writes from the fastly plugin have also been converted to use the esc_sql() function provided by Wordpress to sanitize the content prior to persisting it.

Similarly CSRF tokens have been introduced to the AJAX handlers present in lib/admin.php and the corresponding POSTs in the static/fastly.js file. Its not entirely clear if this functionality is being used in the app but has been patched to address the lack of CSRF tokens regardless. 

Many thanks to Zack Tollman for the initial reports & advisement on the mitigation patches.