### PR TITLE
fix header value array in api and add soft purge option

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -39,7 +39,8 @@ class FastlyAdmin {
     $this->api = new FastlyAPI(
       get_option('fastly_api_key'),
       get_option('fastly_api_hostname'),
-      get_option('fastly_api_port')
+      get_option('fastly_api_port'),
+      get_option('fastly_api_soft')
     );
   }
 
@@ -154,6 +155,7 @@ class FastlyAdmin {
     register_setting('fastly-group', 'fastly_api_key');
     register_setting('fastly-group', 'fastly_service_id');
     register_setting('fastly-group', 'fastly_log_purges');
+    register_setting('fastly-group', 'fastly_api_soft');
     
     // Page change group
     register_setting('fastly-page-group', 'fastly_page');
@@ -298,6 +300,7 @@ class FastlyAdmin {
             <p><b>Fastly API Port</b></p>
             <p><input class="text" name="fastly_api_port" type="text" value="' . esc_attr(get_option('fastly_api_port')) . '"></p>
             <p><input class="checkbox" name="fastly_log_purges" type="checkbox" value="1" ' . ((int)get_option('fastly_log_purges')?"checked='checked'":"") . '> <b>Log purges to PHP errorlog</b></p>
+            <p><input class="checkbox" name="fastly_api_soft" type="checkbox" value="1" ' . ((int)get_option('fastly_api_soft')?"checked='checked'":"") . '> <b>Enable soft purges</b></p>
             
             <!--
             <p><b></b></p>

--- a/lib/api.php
+++ b/lib/api.php
@@ -66,7 +66,7 @@ class FastlyAPI {
 
     $headers = array();
     if ($this->api_key) {
-      $headers[] = "Fastly-Key: " . $this->api_key;
+      $headers['Fastly-Key'] = $this->api_key;
     }
 
     $ch  = curl_init();

--- a/lib/api.php
+++ b/lib/api.php
@@ -13,10 +13,11 @@ class FastlyAPI {
    * @param $host Hostname of the API server.
    * @param $port Port for the API server.
    */
-  function FastlyAPI($api_key='', $host='https://app.fastly.com', $port=null) {
+  function FastlyAPI($api_key='', $host='https://app.fastly.com', $port=null, $soft=null) {
     $this->api_key   = $api_key;
     $this->host      = $host;
     $this->port      = $port;
+    $this->soft      = $soft;
     $this->host_name = preg_replace('/^(ssl|https?):\/\//', '', $host);
   }
   
@@ -67,6 +68,10 @@ class FastlyAPI {
     $headers = array();
     if ($this->api_key) {
       $headers['Fastly-Key'] = $this->api_key;
+    }
+
+    if ($this->soft) {
+      $headers['Fastly-Soft-Purge'] = '1';
     }
 
     $ch  = curl_init();

--- a/lib/purge.php
+++ b/lib/purge.php
@@ -45,7 +45,8 @@ class FastlyPurge {
     $this->api = new FastlyAPI(
       get_option('fastly_api_key'), 
       get_option('fastly_api_hostname'),
-      get_option('fastly_api_port')
+      get_option('fastly_api_port'),
+      get_option('fastly_api_soft')
     );
   }
   


### PR DESCRIPTION
The Fastly-Key header was being set like this when I was testing:

0: Fastly-Key: key value

wp_remote_request's header array seems to be an associative array of key => value 

Also added soft-purge option to advanced tab to set soft purge header
