### PR TITLE
add a note about prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Integrates Fastly with WordPress' publishing tools.
 
+## Prerequisite
+
+The server must have "php5-curl" installed on the server you are hosting Wordpress with.
+
+    sudo apt-get install php5-curl
+
 ## Installation
 
 You can either install from source (you're looking at it), or from the WordPress [plugin directory](http://wordpress.org/plugins/fastly/).


### PR DESCRIPTION
With a fresh install of Wordpress I noticed that Fastly was throwing errors because "php5-curl" was not installed by default.