### PR TITLE
Use trailingslashit for API requests

### DIFF
--- a/src/classes/vcl-handler.php
+++ b/src/classes/vcl-handler.php
@@ -72,7 +72,7 @@ class Vcl_Handler
         }
 
         // Set credentials based data (API url, headers, last version)
-        $this->_version_base_url = $this->_hostname . '/service/' . $this->_service_id . '/version';
+        $this->_version_base_url = trailingslashit($this->_hostname) . 'service/' . $this->_service_id . '/version';
         $this->_headers_get = array(
             'Fastly-Key' => $this->_api_key,
             'Accept' => 'application/json'

--- a/src/utils.php
+++ b/src/utils.php
@@ -111,7 +111,7 @@ function test_fastly_api_connection($hostname, $service_id, $api_key)
         return array('status' => false, 'message' => __('Please enter credentials first'));
     }
 
-    $url = $hostname . '/service/' . $service_id;
+    $url = trailingslashit($hostname) . 'service/' . $service_id;
     $headers = array(
         'Fastly-Key' => $api_key,
         'Accept' => 'application/json'


### PR DESCRIPTION
In both `test_fastly_api_connection` and the constructor of `Vcl_Handler`, the hostname variable was being used but there was nothing done to check to see if there was a trailing slash or not. In other parts of the plugin, the function `trailingslashit` was used, so this seemed like a good way to do it.

The README recommends (and also as the default for `PURGELY_API_ENDPOINT`) to use `https://api.fastly.com/` as the endpoint, but this causes issues with the test connection and in the `Vcl_Handler` class.

This is what currently happens on the master branch for me:

![broken](https://user-images.githubusercontent.com/1558388/28221519-9d69785c-6891-11e7-9534-f718e8639db1.gif)

And this is what happens after this patch:

![good](https://user-images.githubusercontent.com/1558388/28221525-a8e58e64-6891-11e7-919f-bb2b697954cf.gif)