### PR TITLE
add a sitecode

### DIFF
--- a/src/classes/related-surrogate-keys.php
+++ b/src/classes/related-surrogate-keys.php
@@ -8,6 +8,8 @@
 class Purgely_Related_Surrogate_Keys
 {
 
+    private $_sitecode = "";
+
     /**
      * The post ID from which relationships are determined.
      *
@@ -36,11 +38,13 @@ class Purgely_Related_Surrogate_Keys
      */
     public function __construct($identifier)
     {
+        // get the sitecode
+        $this->_sitecode = Purgely_Settings::get_setting('sitecode');
         // Pull the post object from the $identifiers array and setup a standard post object.
         $this->set_post_id($identifier);
         $this->set_post(get_post($identifier));
         // Insert identifier
-        $this->_collection[] = 'p-' . $identifier;
+        $this->_collection[] = 'p-' . $identifier . $this->_sitecode;
     }
 
     /**
@@ -75,11 +79,12 @@ class Purgely_Related_Surrogate_Keys
      */
     static public function get_always_purged_types()
     {
+        $sc = Purgely_Settings::get_setting('sitecode');
         return array(
-            'tm-post',
-            'tm-home',
-            'tm-feed',
-            'holos'
+            'tm-post' . $sc,
+            'tm-home' . $sc,
+            'tm-feed' . $sc,
+            'holos' . $sc
         );
     }
 
@@ -111,7 +116,7 @@ class Purgely_Related_Surrogate_Keys
         if (is_array($terms)) {
             foreach ($terms as $term) {
                 if ($term) {
-                    $key = 't-' . $term;
+                    $key = 't-' . $term . $this->_sitecode;
                     $this->_collection[] = $key;
                 }
             }
@@ -128,7 +133,7 @@ class Purgely_Related_Surrogate_Keys
 
         if ($post = $this->get_post($post_id)) {
             $post->post_author;
-            $key = 'a-' . absint($post->post_author);
+            $key = 'a-' . absint($post->post_author) . $this->_sitecode;
             $this->_collection[] = $key;
         }
     }

--- a/src/classes/settings.php
+++ b/src/classes/settings.php
@@ -111,6 +111,10 @@ class Purgely_Settings
                 'sanitize_callback' => 'purgely_sanitize_checkbox',
                 'default' => PURGELY_WEBHOOKS_ACTIVATE,
             ),
+            'sitecode' => array(
+                'sanitize_callback' => 'sanitize_key',
+                'default' => PURGELY_SITECODE,
+            ),
         );
     }
 

--- a/src/classes/surrogate-key-collection.php
+++ b/src/classes/surrogate-key-collection.php
@@ -12,6 +12,7 @@ class Purgely_Surrogate_Key_Collection
      * @var array The surrogate keys that will be set.
      */
     private $_keys = array();
+    private $_sitecode = "";
 
     /**
      * Construct the object.
@@ -20,6 +21,8 @@ class Purgely_Surrogate_Key_Collection
      */
     public function __construct($wp_query)
     {
+        // get the sitecode
+        $this->_sitecode = Purgely_Settings::get_setting('sitecode');
         // Register the keys that need to be set for the current request, starting with post IDs.
         $keys = $this->_add_key_post_ids($wp_query);
 
@@ -69,7 +72,7 @@ class Purgely_Surrogate_Key_Collection
         $keys = array();
 
         foreach ($wp_query->posts as $post) {
-            $keys[] = 'p-' . absint($post->ID);
+            $keys[] = 'p-' . absint($post->ID) . $this->_sitecode;
         }
 
         return $keys;
@@ -140,7 +143,7 @@ class Purgely_Surrogate_Key_Collection
 
         // Only set the key if it exists.
         if (!empty($template_type)) {
-            $key = 'tm-' . $template_type;
+            $key = 'tm-' . $template_type . $this->_sitecode;
         }
 
         return (array)$key;
@@ -162,7 +165,7 @@ class Purgely_Surrogate_Key_Collection
         if ($terms) {
             foreach ($terms as $term) {
                 if (isset($term->term_id)) {
-                    $keys[] = 't-' . $term->term_id;
+                    $keys[] = 't-' . $term->term_id . $this->_sitecode;
                 }
             }
         }
@@ -183,7 +186,7 @@ class Purgely_Surrogate_Key_Collection
         // archive page? author page? single post?
 
         if (!empty($queried_object->term_id) && !empty($queried_object->taxonomy)) {
-            $keys[] = 't-' . absint($queried_object->term_id);
+            $keys[] = 't-' . absint($queried_object->term_id) . $this->_sitecode;
         }
 
         return $keys;
@@ -202,7 +205,7 @@ class Purgely_Surrogate_Key_Collection
         $key = array();
 
         if ($author > 0) {
-            $key[] = 'a-' . absint($author);
+            $key[] = 'a-' . absint($author) . $this->_sitecode;
         }
 
         return $key;

--- a/src/config.php
+++ b/src/config.php
@@ -142,3 +142,10 @@ if (!defined('PURGELY_WEBHOOKS_CHANNEL')) {
 if (!defined('PURGELY_WEBHOOKS_ACTIVATE')) {
     define('PURGELY_WEBHOOKS_ACTIVATE', false);
 }
+
+/**
+ * unique site code
+ */
+if (!defined('PURGELY_SITECODE')) {
+    define('PURGELY_SITECODE', '');
+}

--- a/src/settings-page.php
+++ b/src/settings-page.php
@@ -189,6 +189,15 @@ class Purgely_Settings_Page
             'purgely-fastly_settings'
         );
 
+        add_settings_field(
+            'sitecode',
+            __('Optional Sitecode for Keys', 'purgely'),
+            array($this, 'sitecode_render'),
+            'fastly-settings-general',
+            'purgely-fastly_settings'
+        );
+
+
         // Register all of the ADVANCED settings.
         add_settings_section(
             'purgely-advanced_settings',
@@ -1430,6 +1439,24 @@ class Purgely_Settings_Page
         </p>
         <?php
     }
+
+    /**
+     * Render the sitecode.
+     *
+     * @return void
+     */
+    public function sitecode_render()
+    {
+        $options = Purgely_Settings::get_settings();
+        ?>
+        <input type='text' name='fastly-settings-general[sitecode]'
+                value='<?php echo esc_attr($options['sitecode']); ?>' size="<?php echo self::INPUT_SIZE ?>">
+        <p class="description">
+            <?php esc_html_e('add a sitecode to surrogate keys', 'purgely'); ?>
+        </p>
+        <?php
+    }
+
 
     /**
      * Print the general settings page.

--- a/src/utils.php
+++ b/src/utils.php
@@ -57,6 +57,7 @@ function purgely_get_options()
         'surrogate_control_ttl',
         'cache_control_ttl',
         'default_purge_type',
+        'sitecode',
     );
 
     $options = array();


### PR DESCRIPTION
for when you have multiple wp sites using a common fastly config this will allow the surrogate keys to be unique per site