### PR TITLE
Sitecode2

### DIFF
--- a/src/classes/header-surrogate-keys.php
+++ b/src/classes/header-surrogate-keys.php
@@ -71,8 +71,13 @@ class Purgely_Surrogate_Keys_Header extends Purgely_Header
         $header_size_bytes = mb_strlen($header_string, '8bit');
         if ($header_size_bytes >= FASTLY_MAX_HEADER_SIZE) {
             // Set to be always purged
+            $siteId = false;
             if(is_multisite()) {
                 $siteId = get_current_blog_id();
+            } elseif($sitecode = Purgely_Settings::get_setting('sitecode')) {
+                $siteId = $sitecode;
+            }
+            if($siteId) {
                 return $siteId . '-' . 'holos';
             }
             return 'holos';
@@ -89,8 +94,13 @@ class Purgely_Surrogate_Keys_Header extends Purgely_Header
     {
         $keys = $this->get_keys();
 
+        $siteId = false;
         if(is_multisite()) {
             $siteId = get_current_blog_id();
+        } elseif($sitecode = Purgely_Settings::get_setting('sitecode')) {
+            $siteId = $sitecode;
+        }
+        if($siteId) {
             foreach($keys as $index => $key) {
                 $keys[$index] = $siteId . '-' . $key;
             }

--- a/src/classes/related-surrogate-keys.php
+++ b/src/classes/related-surrogate-keys.php
@@ -55,7 +55,9 @@ class Purgely_Related_Surrogate_Keys
         $this->locate_author_surrogate_key($this->get_post_id());
         $this->include_always_purged_types();
 
-        if(is_multisite()) {
+        $sitecode = Purgely_Settings::get_setting('sitecode');
+
+        if(is_multisite() or $sitecode) {
             $this->appendMultiSiteIdToCollection();
         }
 
@@ -161,7 +163,12 @@ class Purgely_Related_Surrogate_Keys
      */
     public function appendMultiSiteIdToCollection()
     {
-        $siteId = get_current_blog_id();
+        $siteId = "0"; // a default
+        if (is_multisite()) {
+            $siteId = get_current_blog_id();
+        } else {
+            $siteId = Purgely_Settings::get_setting('sitecode');
+        }
 
         foreach($this->_collection as $index => $key) {
             if(empty($key)) {

--- a/src/classes/settings.php
+++ b/src/classes/settings.php
@@ -99,6 +99,10 @@ class Purgely_Settings
                 'sanitize_callback' => 'sanitize_key',
                 'default' => PURGELY_DEFAULT_PURGE_TYPE,
             ),
+            'sitecode' => array(
+                'sanitize_callback' => 'sanitize_key',
+                'default' => FASTLY_SITECODE,
+            ),
             'custom_ttl_templates' => array(
                 'sanitize_callback' => 'purgely_sanitize_ttl_templates',
                 'default' => array(),

--- a/src/config.php
+++ b/src/config.php
@@ -162,3 +162,7 @@ if (!defined('FASTLY_MAX_HEADER_KEY_SIZE')) {
 if (!defined('FASTLY_MAX_HEADER_SIZE')) {
     define('FASTLY_MAX_HEADER_SIZE', 16384);
 }
+
+if (!defined('FASTLY_SITECODE')) {
+    define('FASTLY_SITECODE', false);
+}

--- a/src/settings-page.php
+++ b/src/settings-page.php
@@ -247,7 +247,7 @@ class Purgely_Settings_Page
 
         add_settings_field(
             'sitecode',
-            __('Optional Sitecode for Keys -- not MultiSite', 'purgely'),
+            __('Optional Sitecode for Surrogate Keys', 'purgely'),
             array($this, 'sitecode_render'),
             'fastly-settings-advanced',
             'purgely-advanced_settings'
@@ -962,10 +962,15 @@ class Purgely_Settings_Page
     {
         $options = Purgely_Settings::get_settings();
         ?>
+        <?php if(is_multisite()) { ?>
+        <input type='text' name='notmuch'
+               value='' size="<?php echo self::INPUT_SIZE ?>" readonly >
+        <?php } else { ?>
         <input type='text' name='fastly-settings-advanced[sitecode]'
                value='<?php echo esc_attr($options['sitecode']); ?>' size="<?php echo self::INPUT_SIZE ?>">
+        <?php } ?>
         <p class="description">
-        <?php esc_html_e('add a sitecode to surrogate keys', 'purgely'); ?>
+        <?php esc_html_e('add a sitecode to surrogate keys.  multisite does this automatically', 'purgely'); ?>
         </p>
         <?php
     }

--- a/src/settings-page.php
+++ b/src/settings-page.php
@@ -245,6 +245,15 @@ class Purgely_Settings_Page
             'purgely-advanced_settings'
         );
 
+        add_settings_field(
+            'sitecode',
+            __('Optional Sitecode for Keys -- not MultiSite', 'purgely'),
+            array($this, 'sitecode_render'),
+            'fastly-settings-advanced',
+            'purgely-advanced_settings'
+        );
+
+
         // Set up the stale content settings.
         add_settings_section(
             'purgely-stale_settings',
@@ -940,6 +949,23 @@ class Purgely_Settings_Page
                value='<?php echo esc_attr($options['cache_control_ttl']); ?>' size="<?php echo self::INPUT_SIZE ?>">
         <p class="description">
             <?php esc_html_e('This setting controls the "cache-control" header\'s "max-age" value. It specifies how long end users/browsers should cache pages', 'purgely'); ?>
+        </p>
+        <?php
+    }
+
+    /**
+     * Render the setting input.
+     *
+     * @return void
+     */
+    public function sitecode_render()
+    {
+        $options = Purgely_Settings::get_settings();
+        ?>
+        <input type='text' name='fastly-settings-advanced[sitecode]'
+               value='<?php echo esc_attr($options['sitecode']); ?>' size="<?php echo self::INPUT_SIZE ?>">
+        <p class="description">
+        <?php esc_html_e('add a sitecode to surrogate keys', 'purgely'); ?>
         </p>
         <?php
     }

--- a/src/utils.php
+++ b/src/utils.php
@@ -58,6 +58,7 @@ function purgely_get_options()
         'surrogate_control_ttl',
         'cache_control_ttl',
         'default_purge_type',
+        'sitecode',
     );
 
     $options = array();


### PR DESCRIPTION
take2 based on more recent code.

This is a patch allowing you to append a "sitecode" to generated surrogate-keys which is useful in the case where you have www.blog1.com and www.blog2.com hosted in your common "Wordpress" fastly service, but are not using wordpress' builtin multisite.