### PR TITLE
[WIP] Use WP HTTP wrapper functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "fastly/fastly-wp",
+  "description": "The Official Fastly WordPress Plugin.",
+  "homepage": "https://github.com/fastly/WordPress-Plugin",
+  "type": "wordpress-plugin",
+  "license"    : "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Fastly",
+      "email": "support@fastly.com"
+    }
+  ],
+  "support"    : {
+    "issues": "https://github.com/fastly/WordPress-Plugin/issues",
+    "source": "https://github.com/fastly/WordPress-Plugin"
+  },
+  "require": {
+    "php": ">=5.2",
+    "composer/installers": "~1.0"
+  }
+}

--- a/src/classes/purge-request.php
+++ b/src/classes/purge-request.php
@@ -64,17 +64,18 @@ class Purgely_Purge
         $request_method = $this->_build_request_method_type($type);
 
         if (($request_uri && !empty($thing)) || ($request_uri && $type = self::ALL)) {
-            try {
-                $response = Requests::request($request_uri, $headers, array(), $request_method);
+            $response = wp_remote_request($request_uri, ['headers' => $headers, 'method' => $request_method]);
+            $response_code = wp_remote_retrieve_response_code($response);
 
-                // Do logging where needed
-                $message = $this->_get_purge_data_message();
-                handle_logging($response, $message);
+            // Do logging where needed
+            $message = $this->_get_purge_data_message();
+            handle_logging($response, $message);
 
-                return $response->success;
-            } catch (Exception $e) {
-                error_log($e->getMessage());
+            if (is_wp_error($response)) {
+            	error_log($response->get_error_message());
             }
+
+            return $response_code === 200;
         }
         return false;
     }
@@ -142,7 +143,7 @@ class Purgely_Purge
         if ($type === Purgely_Purge::URL) {
             return Purgely_Purge::PURGE;
         } else {
-            return Requests::POST;
+            return 'POST';
         }
     }
 

--- a/src/classes/vcl-handler.php
+++ b/src/classes/vcl-handler.php
@@ -467,10 +467,10 @@ class Vcl_Handler
         $response = wp_remote_post($url, ['headers' => $this->_headers_post, 'body' => $data]);
 
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
-            return array();
+            return false;
         }
 
-        return false;
+        return array();
     }
 
     /**

--- a/src/classes/vcl-handler.php
+++ b/src/classes/vcl-handler.php
@@ -129,94 +129,95 @@ class Vcl_Handler
             return false;
         }
 
-        try {
-            if (false === $this->clone_last_active_version()) {
-                $this->add_error(__('Unable to clone last version'));
+        if (false === $this->clone_last_active_version()) {
+            $this->add_error(__('Unable to clone last version'));
+            return false;
+        }
+
+        $requests = array();
+
+        if (!empty($this->_vcl_data)) {
+            $requests = array_merge($requests, $this->prepare_vcl());
+        }
+
+        if (!empty($this->_condition_data)) {
+            $conditions = $this->prepare_condition();
+            if (false === $conditions) {
+                $this->add_error(__('Unable to insert new condition'));
                 return false;
             }
+            $requests = array_merge($requests, $conditions);
+        }
 
-            $requests = array();
+        if (!empty($this->_header_data)) {
+            $requests = array_merge($requests, $this->prepare_header());
+        }
 
-            if (!empty($this->_vcl_data)) {
-                $requests = array_merge($requests, $this->prepare_vcl());
+        if (!empty($this->_setting_data)) {
+            $requests = array_merge($requests, $this->prepare_setting());
+        }
+
+        if (!empty($this->_response_object_data)) {
+            $requests = array_merge($requests, $this->prepare_response_object());
+        }
+
+        if (!$this->validate_version()) {
+            $this->add_error(__('Version not validated'));
+            return false;
+        }
+
+        $responses = [];
+
+        // Set Request Headers
+        foreach ($requests as $key => $request) {
+            $headers = $this->_headers_get;
+            if (in_array($request['type'], array('POST', 'PUT'))) {
+                $headers = $this->_headers_post;
             }
+            $responses[] = wp_remote_request($request['url'], [
+                'headers' => $headers,
+                'body' => $request['data'],
+                'method' => $request['type'],
+            ]);
+        }
 
-            if (!empty($this->_condition_data)) {
-                $conditions = $this->prepare_condition();
-                if (false === $conditions) {
-                    $this->add_error(__('Unable to insert new condition'));
-                    return false;
-                }
-                $requests = array_merge($requests, $conditions);
+        $pass = true;
+        foreach ($responses as $response) {
+            if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+                $pass = false;
+                $this->add_error(__('Some of the API requests failed, enable debugging and check logs for more information.'));
+
+                $message = sprintf('VCL update failed : %s',
+                    is_wp_error($response) ? $response->get_error_message() : wp_remote_retrieve_body($response)
+                );
+
+                handle_logging($response, $message);
             }
+        }
 
-            if (!empty($this->_header_data)) {
-                $requests = array_merge($requests, $this->prepare_header());
-            }
+        // Activate version if vcl is successfully uploaded
+        if ($pass && $activate) {
+            $request = $this->prepare_activate_version();
+			$response = wp_remote_request($request['url'], [
+				'headers' => $request['headers'],
+				'method' => $request['type'],
+			]);
+            if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+                $pass = false;
+                $this->add_error(__('Some of the API requests failed, enable debugging and check logs for more information.'));
 
-            if (!empty($this->_setting_data)) {
-                $requests = array_merge($requests, $this->prepare_setting());
-            }
+                $message = sprintf('VCL update failed : %s',
+	                is_wp_error($response) ? $response->get_error_message() : wp_remote_retrieve_body($response)
+                );
 
-            if (!empty($this->_response_object_data)) {
-                $requests = array_merge($requests, $this->prepare_response_object());
-            }
-
-            if (!$this->validate_version()) {
-                $this->add_error(__('Version not validated'));
-                return false;
-            }
-
-            // Set Request Headers
-            foreach ($requests as $key => $request) {
-                if (in_array($request['type'], array(Requests::POST, Requests::PUT))) {
-                    $requests[$key]['headers'] = $this->_headers_post;
-                } else {
-                    $requests[$key]['headers'] = $this->_headers_get;
-                }
-            }
-
-            // Send Requests
-            $responses = Requests::request_multiple($requests);
-
-            $pass = true;
-            foreach ($responses as $response) {
-                if (!$response->success) {
-                    $pass = false;
-                    $this->add_error(__('Some of the API requests failed, enable debugging and check logs for more information.'));
-
-                    $message = 'VCL update failed : ' . $response->body;
-                    handle_logging($response, $message);
-                }
-            }
-
-            // Activate version if vcl is successfully uploaded
-            if ($pass && $activate) {
-                $request = $this->prepare_activate_version();
-
-                $response = Requests::request($request['url'], $request['headers'], array(), $request['type']);
-                if (!$response->success) {
-                    $pass = false;
-                    $this->add_error(__('Some of the API requests failed, enable debugging and check logs for more information.'));
-
-                    $message = 'Activation of new version failed : ' . $response->body;
-                    handle_logging($response, $message);
-                } else {
-                    $message = 'VCL updated, version activated : ' . $this->_last_cloned_version;
-                    send_web_hook($message);
-                }
-            } elseif ($pass && !$activate) {
-                $message = 'VCL updated, but not activated.';
+                handle_logging($response, $message);
+            } else {
+                $message = 'VCL updated, version activated : ' . $this->_last_cloned_version;
                 send_web_hook($message);
             }
-
-        } catch (Exception $e) {
-            $this->add_error(__('Some of the API requests failed, enable debugging and check logs for more information.'));
-            $message = 'VCL update failed : ' . $e->getMessage();
+        } elseif ($pass && !$activate) {
+            $message = 'VCL updated, but not activated.';
             send_web_hook($message);
-            error_log($message);// Force log this, possibly no response object
-
-            return false;
         }
 
         return $pass;
@@ -290,9 +291,9 @@ class Vcl_Handler
         }
 
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/snippet/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
 
-        return $response->success;
+        return wp_remote_retrieve_response_code($response) === 200;
     }
 
     /**
@@ -307,7 +308,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::PUT
+            'type' => 'PUT'
         );
 
         return $request;
@@ -325,7 +326,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::POST
+            'type' => 'POST'
         );
 
         return $request;
@@ -342,7 +343,7 @@ class Vcl_Handler
 
         $request = array(
             'url' => $url,
-            'type' => Requests::DELETE
+            'type' => 'DELETE'
         );
 
         return $request;
@@ -355,8 +356,8 @@ class Vcl_Handler
     public function get_last_version()
     {
         $url = $this->_version_base_url;
-        $response = Requests::get($url, $this->_headers_get);
-        $response_data = json_decode($response->body);
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        $response_data = json_decode(wp_remote_retrieve_body($response));
 
         $this->_next_cloned_version_num = count($response_data) + 1;
 
@@ -381,9 +382,9 @@ class Vcl_Handler
 
         $version_number = $this->_last_version_data->number;
         $url = $this->_version_base_url . '/' . $version_number . '/clone';
-        $response = Requests::put($url, $this->_headers_post);
+        $response = wp_remote_request($url, ['headers' => $this->_headers_post, 'method' => 'PUT']);
 
-        $response_data = json_decode($response->body);
+        $response_data = json_decode(wp_remote_retrieve_body($response));
         $cloned_version_number = isset($response_data->number) ? $response_data->number : false;
         $this->_last_cloned_version = $cloned_version_number;
 
@@ -432,8 +433,8 @@ class Vcl_Handler
     public function get_condition($name)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/condition/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
-        return $response->success;
+        $response = wp_remote_get( $url, ['headers' => $this->_headers_get] );
+        return wp_remote_retrieve_response_code($response) === 200;
     }
 
     /**
@@ -448,7 +449,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::PUT
+            'type' => 'PUT'
         );
 
         return $request;
@@ -457,25 +458,19 @@ class Vcl_Handler
     /**
      * Prepare condition for insert
      * @data
-     * @return array
+     * @return array|false
      */
     public function insert_condition($data)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/condition';
 
-        $request = array(
-            'url' => $url,
-            'data' => $data,
-            'type' => Requests::POST
-        );
+        $response = wp_remote_post($url, ['headers' => $this->_headers_post, 'body' => $data]);
 
-        $response = Requests::request($request['url'], $this->_headers_post, $request['data'], $request['type']);
-
-        if ($response->success) {
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
             return array();
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -488,15 +483,7 @@ class Vcl_Handler
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/condition/' . $name;
 
-        $request = array(
-            'url' => $url,
-            'type' => Requests::DELETE
-        );
-
-        $response = Requests::request($request['url'], $this->_headers_post, array(), $request['type']);
-
-        // If condition does not exist, thats ok too
-        return array();
+        return wp_remote_request($url, ['headers' => $this->_headers_post, 'method' => 'DELETE']);
     }
 
     /**
@@ -543,8 +530,8 @@ class Vcl_Handler
     public function get_header($name)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/header/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
-        return $response->success;
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        return wp_remote_retrieve_response_code($response->success) === 200;
     }
 
     /**
@@ -559,7 +546,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::PUT
+            'type' => 'PUT',
         );
 
         return $request;
@@ -568,25 +555,19 @@ class Vcl_Handler
     /**
      * Prepare header for insert
      * @data
-     * @return array
+     * @return array|false
      */
     public function insert_header($data)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/header';
 
-        $request = array(
-            'url' => $url,
-            'data' => $data,
-            'type' => Requests::POST
-        );
+        $response = wp_remote_post($url, ['headers' => $this->_headers_post, 'body' => $data]);
 
-        $response = Requests::request($request['url'], $this->_headers_post, $request['data'], $request['type']);
-
-        if ($response->success) {
+        if (wp_remote_retrieve_response_code($response) === 200) {
             return array();
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -599,12 +580,7 @@ class Vcl_Handler
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/header/' . $name;
 
-        $request = array(
-            'url' => $url,
-            'type' => Requests::DELETE
-        );
-
-        $response = Requests::request($request['url'], $this->_headers_post, array(), $request['type']);
+        wp_remote_request($url, ['headers' => $this->_headers_post, 'method' => 'DELETE']);
 
         // If condition does not exist, thats ok too
         return array();
@@ -657,8 +633,8 @@ class Vcl_Handler
     public function get_setting($name)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/request_settings/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
-        return $response->success;
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        return wp_remote_retrieve_response_code($response->success) === 200;
     }
 
     /**
@@ -673,7 +649,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::PUT
+            'type' => 'PUT'
         );
 
         return $request;
@@ -691,7 +667,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::POST
+            'type' => 'POST'
         );
 
         return $request;
@@ -708,7 +684,7 @@ class Vcl_Handler
 
         $request = array(
             'url' => $url,
-            'type' => Requests::DELETE
+            'type' => 'DELETE'
         );
 
         return $request;
@@ -748,8 +724,8 @@ class Vcl_Handler
     public function get_response_object($name)
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/response_object/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
-        return $response->success;
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        return wp_remote_retrieve_response_code($response) === 200;
     }
 
     /**
@@ -764,8 +740,8 @@ class Vcl_Handler
             return false;
         }
         $url = $this->_version_base_url . '/' . $version_num . '/response_object/' . $name;
-        $response = Requests::get($url, $this->_headers_get);
-        return $response;
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        return wp_remote_retrieve_body($response);
     }
 
     /**
@@ -780,7 +756,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::PUT
+            'type' => 'PUT',
         );
 
         return $request;
@@ -798,7 +774,7 @@ class Vcl_Handler
         $request = array(
             'url' => $url,
             'data' => $data,
-            'type' => Requests::POST
+            'type' => 'POST',
         );
 
         return $request;
@@ -811,8 +787,8 @@ class Vcl_Handler
     public function validate_version()
     {
         $url = $this->_version_base_url . '/' . $this->_last_cloned_version . '/validate';
-        $response = Requests::get($url, $this->_headers_get);
-        return $response->success;
+        $response = wp_remote_get($url, ['headers' => $this->_headers_get]);
+        return wp_remote_retrieve_response_code($response) === 200;
     }
 
     /**
@@ -825,7 +801,7 @@ class Vcl_Handler
 
         $request = array(
             'url' => $url,
-            'type' => Requests::PUT,
+            'type' => 'PUT',
             'headers' => $this->_headers_get
         );
 
@@ -841,14 +817,15 @@ class Vcl_Handler
         if(!$this->_hostname || !$this->_service_id) {
             return false;
         }
-        try {
-            $url = trailingslashit($this->_hostname) . 'service/' . $this->_service_id . '/dynamic_io_settings';
-            $response = Requests::get($url, $this->_headers_get);
-            return $response->success;
-        } catch (Exception $e) {
-            error_log($e->getMessage());
+
+        $url = trailingslashit($this->_hostname) . 'service/' . $this->_service_id . '/dynamic_io_settings';
+        $response = wp_remote_get( $url, ['headers' => $this->_headers_get] );
+
+        if (is_wp_error($response)) {
+            error_log($response->get_error_message());
         }
-        return false;
+
+        return wp_remote_retrieve_response_code($response) === 200;
     }
 
     /**

--- a/src/utils.php
+++ b/src/utils.php
@@ -157,7 +157,6 @@ function purgely_sanitize_pixel_ratios($value)
  */
 function test_fastly_api_connection($hostname, $service_id, $api_key)
 {
-
     if (empty($hostname) || empty($service_id) || empty($api_key)) {
         return array('status' => false, 'message' => __('Please enter credentials first'));
     }
@@ -171,18 +170,19 @@ function test_fastly_api_connection($hostname, $service_id, $api_key)
     $purgely_instance = Purgely::instance();
     if(empty($purgely_instance->connection_status)) {
         try {
-            $response = Requests::get($url, $headers);
-            if ($response->success) {
-                $response_body = json_decode($response->body);
+            $response = wp_remote_get($url, ['headers' => $headers]);
+            $response_code = wp_remote_retrieve_response_code($response);
+            $response_body = json_decode(wp_remote_retrieve_body($response));
+            if ($response_code === 200) {
                 $service_name = $response_body->name;
                 $purgely_instance->service_name = $service_name;
                 $message = __('Connection Successful on service *' . $service_name . "*");
             } else {
                 handle_logging($response);
-                $message = json_decode($response->body);
+                $message = $response_body;
                 $message = $message->msg;
             }
-            $purgely_instance->connection_status = array('status' => $response->success, 'message' => $message);
+            $purgely_instance->connection_status = array('status' => ($response_code === 200), 'message' => $message);
         } catch (Exception $e) {
             $purgely_instance->connection_status = array('status' => false, 'message' => $e->getMessage());
         }
@@ -206,24 +206,22 @@ function send_web_hook($message)
     $channel = Purgely_Settings::get_setting('webhooks_channel');
 
     $headers = array('Content-type: application/json');
-    $data = json_encode(
-        array(
-            'text' => $message,
-            'username' => $username,
-            'channel' => '#' . $channel,
-            'icon_emoji' => ':airplane:'
-        )
+    $data = array(
+        'text' => $message,
+        'username' => $username,
+        'channel' => '#' . $channel,
+        'icon_emoji' => ':airplane:'
     );
 
-    try {
-        $response = Requests::request($webhook_url, $headers, $data, Requests::POST);
-        if (!$response->success) {
-            if (Purgely_Settings::get_setting('fastly_debug_mode')) {
-                error_log("Webhooks request failed, error: " . json_decode($response->body));
-            }
+    $response = wp_remote_post( $webhook_url, [ 'headers' => $headers, 'body' => $data ] );
+    if (wp_remote_retrieve_response_code($response) !== 200) {
+        if (Purgely_Settings::get_setting('fastly_debug_mode')) {
+            error_log("Webhooks request failed, error: " . json_decode(wp_remote_retrieve_body($response)));
         }
-    } catch (Exception $e) {
-        error_log($e->getMessage());
+    }
+
+    if (is_wp_error($response)) {
+        error_log($response->get_error_message());
     }
 }
 
@@ -239,30 +237,30 @@ function test_web_hook()
     $channel = Purgely_Settings::get_setting('webhooks_channel');
 
     $headers = array('Content-type: application/json');
-    $data = json_encode(
-        array(
+    $data = array(
             'text' => 'Webhook connection successful!',
             'username' => $username,
             'channel' => '#' . $channel,
             'icon_emoji' => ':airplane:'
-        )
     );
 
-    try {
-        $response = Requests::request($webhook_url, $headers, $data, Requests::POST);
-        $message = $response->success ? __('Connection Successful!') : __($response->body);
+    $response = wp_remote_post($webhook_url, ['headers' => $headers, 'body' => $data]);
+    $body = wp_remote_retrieve_body($response);
+    $success = (wp_remote_retrieve_response_code() === 200);
+    $message = $success ? __('Connection Successful!') : __($body);
 
-        if (Purgely_Settings::get_setting('fastly_debug_mode')) {
-            error_log('Webhooks - test connection: ' . $response->body);
-        }
-
-        return array('status' => $response->success, 'message' => $message);
-    } catch (Exception $e) {
-        if (Purgely_Settings::get_setting('fastly_debug_mode')) {
-            error_log('Webhooks - test connection: ' . $e->getMessage());
-        }
-        return array('status' => false, 'message' => $e->getMessage());
+    if (Purgely_Settings::get_setting('fastly_debug_mode')) {
+        error_log('Webhooks - test connection: ' . $body);
     }
+
+	if (is_wp_error($response)) {
+		if (Purgely_Settings::get_setting('fastly_debug_mode')) {
+			error_log('Webhooks - test connection: ' . $response->get_error_message());
+		}
+		return array('status' => false, 'message' => $response->get_error_message());
+	}
+
+    return array('status' => $success, 'message' => $message);
 }
 
 /**
@@ -270,14 +268,18 @@ function test_web_hook()
  * @param Requests_Response $response
  * @param $message
  */
-function handle_logging(Requests_Response $response, $message = false)
+function handle_logging($response, $message = false)
 {
     $debug_mode = Purgely_Settings::get_setting('fastly_debug_mode');
     $log_purges = Purgely_Settings::get_setting('fastly_log_purges');
     $log_slack = Purgely_Settings::get_setting('webhooks_activate');
 
     if ($debug_mode || $log_purges || $log_slack) {
-        $msg = get_message_by_status_code($response->status_code);
+    	if (is_wp_error($response)) {
+    		$msg = $response->get_error_message();
+	    } else {
+		    $msg = get_message_by_status_code(wp_remote_retrieve_response_code($response));
+	    }
         if ($message) {
             $msg = $msg . ' - ' . $message;
         }
@@ -289,8 +291,8 @@ function handle_logging(Requests_Response $response, $message = false)
     if ($log_purges || $debug_mode) {
         if ($log_purges) {
             error_log($msg);
-        } elseif ($debug_mode) {
-            if (!$response->success) {
+        } elseif ($debug_mode && ! is_wp_error($response)) {
+            if (wp_remote_retrieve_response_code($response) !== 200) {
                 error_log($msg);
             }
         }

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -56,9 +56,6 @@ if (!class_exists('Purgely_Command')) :
                 }
             }
 
-            // Set wp original certificate instead of wp-cli certificate
-            Requests::set_certificate_path(ABSPATH . WPINC . '/certificates/ca-bundle.crt');
-
             $purgely = new Purgely_Purge();
 
             // Find related IDs for inputed ID


### PR DESCRIPTION
By using the `Requests` library directly, the plugin skips a lot of bootstrapping provided by WordPress including setting the proxy. See the `request` method in the `WP_Http` class for more detail (https://github.com/WordPress/WordPress/blob/master/wp-includes/class-http.php#L149).

By using the standard WP helpers, you ensure that the correct settings are applied to the external requests.

This PR is still a work in progress. I have tested it in our pre-prod environment and it works correctly, but it still requires further testing and tidying.