### PR TITLE
Improve Service ID or API key sanitizing

### DIFF
--- a/src/utils.php
+++ b/src/utils.php
@@ -80,14 +80,14 @@ function purgely_get_options()
 
 /**
  * Sanitize a Fastly Service ID or API Key.
- * Restricts a value to only a-z, A-Z, and 0-9.
+ * Restricts a value to only a-z, A-Z, 0-9 and -.
  *
  * @param  string $key Unsantizied key.
  * @return string      Sanitized key.
  */
 function purgely_sanitize_key($key)
 {
-    return preg_replace('/[^a-zA-Z0-9]/', '', $key);
+    return preg_replace('/[^a-zA-Z0-9-]/', '', $key);
 }
 
 /**


### PR DESCRIPTION
This PR allows to have the character `-` in the Service ID or API key, as this may happen.

My API key, retrieve from the Fastly website, looks like this `aBc4De-fGh5idgZgEXXXXXXXXXX` (notice the `-`).

Previous to that PR, the `-` would be stripped, resulting to any API call returning a `401 Unauthorized`.

