### PR TITLE
Fix password-protected pages

### DIFF
--- a/vcl_snippets/recv.vcl
+++ b/vcl_snippets/recv.vcl
@@ -24,7 +24,7 @@
 
   if ( req.http.Cookie ) {
     ### do not cache authenticated sessions
-    if (req.http.Cookie ~ "(wordpress_|PHPSESSID)") {
+    if (req.http.Cookie ~ "(wordpress_|wp-postpass_|PHPSESSID)") {
       set req.http.X-Pass = "1";
     } else if (!req.http.X-Pass) {
       # Cleans up cookies by removing everything except vendor_region, PHPSESSID and themetype2


### PR DESCRIPTION
WordPress allows password protecting pages, per https://wordpress.org/support/article/using-password-protection/

When the end-user enters a password, WordPress sets a cookie value prefixed `wp-postpass_` followed by a hash for the URL. 

Previously, since cookies are stripped, the page just "reloads" the cached version after an end user enters the page password.

This change to the VCL bypasses cache for folks with that cookie set. 

To be fair, this does seem awfully broad (password cookies are page-specific), but I'm not sure how to resolve this for only the specific URLs in question. So this is my cheap workaround for the moment. My hope is this at least sparks conversation or brings someone along who knows more about how to *more correctly* do this (page specific?) if this change doesn't seem right for you.