### PR TITLE
Adding support for a custom TTL for the ‘front_page’.

### DIFF
--- a/src/classes/surrogate-key-collection.php
+++ b/src/classes/surrogate-key-collection.php
@@ -22,6 +22,7 @@ class Purgely_Surrogate_Key_Collection
     static public $types = array(
         'single',
         'preview',
+        'front_page',
         'page',
         'archive',
         'date',


### PR DESCRIPTION
There is a `is_front_page()` function, so can be used to add a TTL for the front page which is different from the template type making it up.
See https://codex.wordpress.org/Function_Reference/is_front_page.