### PR TITLE
Added support for modifying the post authors

### DIFF
--- a/src/classes/surrogate-key-collection.php
+++ b/src/classes/surrogate-key-collection.php
@@ -230,11 +230,15 @@ class Purgely_Surrogate_Key_Collection
      */
     private function _add_key_author($post)
     {
-        $author = absint($post->post_author);
+        $authors = array(absint($post->post_author));
+        $authors = apply_filters('purgely_post_authors', $authors, $post);
+
         $key = array();
 
-        if ($author > 0) {
-            $key[] = 'a-' . absint($author);
+        foreach ($authors as $author) {
+            if ($author > 0) {
+                $key[] = 'a-' . absint($author);
+            }
         }
 
         return $key;


### PR DESCRIPTION
For example, if you have most posts created by a single author you probably don’t want every post purged when any one of them changes, so you could use:

```
add_filter('purgely_post_authors', function ($authors, $post) {
    return [];
}, 10, 2);
```
But this does't 

It might seem a bit odd that we changed authors support into multiple, but we thought it was more useful as we do currently support multiple authors for our posts, but happy to switch it to only supporting a single author if you prefer.

Also, it is a little different from `purgely_taxonomy_keys` as it seemed more sensible and flexible to include the post in the filter call.
In fact, I don't think it would hurt adding the post to the `purgely_taxonomy_keys` filter too, but we don't need that ourselves.
