### PR TITLE
Add filter to allow adding/editing keys within the context of Purgely_Related_Surrogate_Keys

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,7 @@ function custom_headers_edit($header_object)
   $header_object->edit_headers(array(\'custom-header\' => \'555\', \'max-age\' => \'99\'));
 }
 
-add_filter(\'purgely_related_keys\', \'custom_related_keys\');
+add_filter(\'purgely_related_keys\', \'custom_related_keys\', 10, 2);
 function custom_related_keys($keys_array, $post_object) {
     $keys_array[] = \'custom-key\';
     return $keys_array;

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,10 @@ More details can be found at https://github.com/fastly/WordPress-Plugin/blob/mas
 
 Available wordpress hooks (add_action) on:
 
-Editing purging keys output
+Editing related (purging) keys for a given post
+ purgely_related_keys
+
+Editing surrogate keys output
  purgely_pre_send_keys
  purgely_post_send_keys
     functions: add_keys
@@ -102,6 +105,12 @@ add_action(\'purgely_pre_send_surrogate_control\', \'custom_headers_edit\');
 function custom_headers_edit($header_object)
 {
   $header_object->edit_headers(array(\'custom-header\' => \'555\', \'max-age\' => \'99\'));
+}
+
+add_filter(\'purgely_related_keys\', \'custom_related_keys\');
+function custom_related_keys($keys_array, $post_object) {
+    $keys_array[] = \'custom-key\';
+    return $keys_array;
 }
 
 add_action(\'purgely_pre_send_keys\', \'custom_surrogate_keys\');

--- a/src/classes/related-surrogate-keys.php
+++ b/src/classes/related-surrogate-keys.php
@@ -60,6 +60,8 @@ class Purgely_Related_Surrogate_Keys
         $this->locate_author_surrogate_key($this->get_post_id());
         $this->include_always_purged_types();
 
+        $this->_collection = apply_filters('purgely_related_keys', $this->_collection, $this->get_post());
+
         $sitecode = Purgely_Settings::get_setting('sitecode');
 
         if(is_multisite() or $sitecode) {


### PR DESCRIPTION
Right now, while it's certainly possible, it can get a bit complicated to set up purging of custom surrogate keys. If I want to purge a key based on a post updating (saving trashing etc), I have to re-hook a number of cases just like the Purgely_Purges classes does.

It would be easier if there was a hook within Purgely_Purges' code path where I could simply see "here is the post being updated." (This would also ensure keys are bundled into as few collections of keys as possible, as opposed to always having to make at least one additional call to Purgely_Purge::purge() with the custom stuff.) This PR adds such a filter to the Purgely_Related_Surrogate_Keys class used to collect keys for purging, and notes it in the readme.

My own use case: I want to set the surrogate key "cpt-my-type" on pages that perform custom aggregation of post type my_type. Then whenever a post of that type is edited, I want the "cpt-my-type" surrogate key purged alongside all the fastly defaults. This PR makes the second part much easier.