### PR TITLE
fix errors in wp-6.2

### DIFF
--- a/src/classes/vcl-handler.php
+++ b/src/classes/vcl-handler.php
@@ -3,6 +3,8 @@
 /**
  * Class to control the VCL handling.
  */
+
+use WpOrg\Requests\Response as Requests;
 class Vcl_Handler
 {
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -1,5 +1,7 @@
 <?php
 
+use WpOrg\Requests\Response as Requests;
+
 /**
  * Sanitize a surrogate key to only allow hash-like keys.
  *
@@ -255,10 +257,10 @@ function test_web_hook()
 
 /**
  * Do logging where needed
- * @param Requests_Response $response
+ * @param object $response
  * @param $message
  */
-function handle_logging(Requests_Response $response, $message = false)
+function handle_logging(object $response, $message = false)
 {
     $debug_mode = Purgely_Settings::get_setting('fastly_debug_mode');
     $log_purges = Purgely_Settings::get_setting('fastly_log_purges');


### PR DESCRIPTION
 Fix errors in wordpress 6.2
Class Request has been deprecated in 6.2
``Uncaught TypeError: Argument 1 passed to handle_logging() must be an instance of Requests_Response, instance of WpOrg\Requests\Response given, called in /code/wp-content/plugins/fastly/src/classes/purge-request.php on line 72 and defined in /code/wp-content/plugins/fastly/src/utils.php:261
Stack trace:
#0 /code/wp-content/plugins/fastly/src/classes/purge-request.php(72): handle_logging(Object(WpOrg\Requests\Response), 'Purging Keys *p...')
#1 /code/wp-content/plugins/fastly/src/wp-purges.php(73): Purgely_Purge->purge('key-collection', Array, Array)
#2 /code/wp-includes/class-wp-hook.php(310): Purgely_Purges->purge(19375)
#3 /code/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#4 /code/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#5 /code/wp-includes/post.php(4715): do_action('save_post', 19375, Object(WP_Post), true)
#6 /code/wp-includes/post.php(4817): wp_insert_post(Array, false, true)
#7 /code/wp-admin/includes/post.php(439): wp_update_post(Array)