### PR TITLE
Fix mismatch between `X-Pass` value in snippet and dynamic rule

### DIFF
--- a/fastly_edge_modules/nocache.json
+++ b/fastly_edge_modules/nocache.json
@@ -34,7 +34,7 @@
 	"vcl": [
 		{
 			"type": "recv",
-			"template": "{{#each rules}}\n{{#ifMatch mode 'both|fastly'}}\nif (req.url ~ \"{{../pathpattern}}\") {\n  set req.http.x-pass = \"1\";\n}\n{{/ifMatch}}\n{{/each}}"
+			"template": "{{#each rules}}\n{{#ifMatch mode 'both|fastly'}}\nif (req.url ~ \"{{../pathpattern}}\") {\n  set req.http.X-Pass = \"1\";\n}\n{{/ifMatch}}\n{{/each}}"
 		},
 		{
 			"type": "deliver",


### PR DESCRIPTION
There is a mismatch between the X-Pass set inside the base recv snippet. and this rule.

This PR fixes some cookie related logic in the main snippet.