### PR TITLE
fix: assignment fix for constants

### DIFF
--- a/src/classes/settings.php
+++ b/src/classes/settings.php
@@ -174,7 +174,7 @@ class Purgely_Settings
             foreach ($registered_settings as $key => $values) {
                 $value = '';
 
-                if (isset($saved_settings[$key])) {
+                if (isset($saved_settings[$key]) && $saved_settings[$key]) {
                     $value = $saved_settings[$key];
                 } else if (isset($values['default'])) {
                     $value = $values['default'];

--- a/src/classes/settings.php
+++ b/src/classes/settings.php
@@ -174,14 +174,14 @@ class Purgely_Settings
             foreach ($registered_settings as $key => $values) {
                 $value = '';
 
-                if (isset($saved_settings[$key]) && $saved_settings[$key]) {
-                    $value = $saved_settings[$key];
-                } else if (isset($values['default'])) {
+                if ( ! empty( $saved_settings[ $key ] ) ) {
+                    $value = $saved_settings[ $key ];
+                } else if ( ! empty( $values['default'] ) ) {
                     $value = $values['default'];
                 }
 
-                if (isset($values['sanitize_callback'])) {
-                    $value = call_user_func($values['sanitize_callback'], $value);
+                if ( ! empty ( $values['sanitize_callback'] ) ) {
+                    $value = call_user_func( $values['sanitize_callback'], $value );
                 }
 
                 $negotiated_settings[$key] = $value;


### PR DESCRIPTION
Bug:
- current conditional only checks whether the key exists, which is does by default, so this always returns true.

Resolution:
- check `isset()` first and then verify that the value isn't empty before assigning it