### PR TITLE
Allowing usage of Fastly service without stored credentials

### DIFF
--- a/src/classes/api.php
+++ b/src/classes/api.php
@@ -24,18 +24,18 @@ class Fastly_Api
     protected function __construct()
     {
         $this->headers_get = [
-            'Fastly-Key' => purgely_get_option('fastly_api_key'),
+            'Fastly-Key' => Purgely_Settings::get_setting('fastly_api_key'),
             'Accept' => 'application/json'
         ];
         $this->headers_post = [
-            'Fastly-Key' => purgely_get_option('fastly_api_key'),
+            'Fastly-Key' => Purgely_Settings::get_setting('fastly_api_key'),
             'Accept' => 'application/json',
             'Content-Type' => 'application/x-www-form-urlencoded'
         ];
         $this->base_url = implode('', [
-            trailingslashit(purgely_get_option('fastly_api_hostname')),
+            trailingslashit(Purgely_Settings::get_setting('fastly_api_hostname')),
             trailingslashit('service'),
-            trailingslashit(purgely_get_option('fastly_service_id')),
+            trailingslashit(Purgely_Settings::get_setting('fastly_service_id')),
         ]);
     }
 
@@ -67,6 +67,11 @@ class Fastly_Api
     {
         if (is_null($this->active_version)) {
             $response = Requests::get($this->base_url.'version', $this->headers_get);
+
+            if ($response->status_code !== 200) {
+                throw new \Exception("Invalid response while fetching active version.");
+            }
+
             foreach (json_decode($response->body) as $version) {
                 if ($version->active) {
                     $this->active_version = $version;

--- a/src/classes/vcl-handler.php
+++ b/src/classes/vcl-handler.php
@@ -64,9 +64,9 @@ class Vcl_Handler
         $this->_header_data = !empty($data['header']) ? $data['header'] : false;
         $this->_response_object_data = !empty($data['response']) ? $data['response'] : false;
 
-        $this->_hostname = purgely_get_option('fastly_api_hostname');
-        $this->_service_id = purgely_get_option('fastly_service_id');
-        $this->_api_key = purgely_get_option('fastly_api_key');
+        $this->_hostname = Purgely_Settings::get_setting('fastly_api_hostname');
+        $this->_service_id = Purgely_Settings::get_setting('fastly_service_id');
+        $this->_api_key = Purgely_Settings::get_setting('fastly_api_key');
 
         $connection = test_fastly_api_connection($this->_hostname, $this->_service_id, $this->_api_key);
         if (!$connection['status']) {

--- a/src/settings-page.php
+++ b/src/settings-page.php
@@ -674,7 +674,7 @@ class Purgely_Settings_Page
         $service_name = $purgely_instance->service_name;
 
         if (!is_null($vcl->_last_active_version_num) && !is_null($vcl->_next_cloned_version_num)) {
-            $service_id = purgely_get_option('fastly_service_id');
+            $service_id = Purgely_Settings::get_setting('fastly_service_id');
             /* translators: %1\$s: current active VCL version, %2\$s: Fastly service name, %3\$s: new VCL version */
             $message = sprintf(
                 __("You are about to clone active version %1\$s for service \"%2\$s\". We'll make changes to version %3\$s", 'purgely'),
@@ -1618,7 +1618,7 @@ class Purgely_Settings_Page
         $service_name = $purgely_instance->service_name;
 
         if (!is_null($vcl->_last_active_version_num) && !is_null($vcl->_next_cloned_version_num)) {
-            $service_id = purgely_get_option('fastly_service_id');
+            $service_id = Purgely_Settings::get_setting('fastly_service_id');
             /* translators: %1\$s: current active VCL version, %2\$s: Fastly service name, %3\$s: new VCL version */
             $message = sprintf(
                     __("You are about to clone active version %1\$s for service \"%2\$s\". We'll make changes to version %3\$s", 'purgely'),
@@ -1740,7 +1740,7 @@ class Purgely_Settings_Page
         $service_name = $purgely_instance->service_name;
 
         if (!is_null($vcl->_last_active_version_num) && !is_null($vcl->_next_cloned_version_num)) {
-            $service_id = purgely_get_option('fastly_service_id');
+            $service_id = Purgely_Settings::get_setting('fastly_service_id');
             /* translators: %1\$s: current active VCL version, %2\$s: Fastly service name, %3\$s: new VCL version */
             $message = sprintf(
                 __("You are about to clone active version %1\$s for service \"%2\$s\". We'll make changes to version %3\$s", 'purgely'),


### PR DESCRIPTION
Changes in settings value fetch - usage of defined constants, such as wp-config, is allowed